### PR TITLE
modify using localtime for retrieving modified domains

### DIFF
--- a/servers/zms/conf/zms.properties
+++ b/servers/zms/conf/zms.properties
@@ -415,3 +415,7 @@ athenz.zms.read_only_mode=false
 # needs to contact most likely a server (e.g. mysql instance)
 # running in a different region.
 #athenz.zms.master_copy_for_signed_domains=false
+
+# Boolean value specifying whether using the server's timezone or GMT
+# at retriving modified domains from DB
+#athenz.zms.use_local_timezone_in_domain_scan=false

--- a/servers/zms/conf/zms.properties
+++ b/servers/zms/conf/zms.properties
@@ -416,6 +416,6 @@ athenz.zms.read_only_mode=false
 # running in a different region.
 #athenz.zms.master_copy_for_signed_domains=false
 
-# Boolean value specifying whether using the server's timezone or GMT
-# at retriving modified domains from DB
-#athenz.zms.use_local_timezone_in_domain_scan=false
+# Set the timezone of the database
+# when retrieving the modified domain.
+#athenz.zms.athenz.zms.mysql_server_timezone=

--- a/servers/zms/src/main/java/com/yahoo/athenz/zms/ZMSConsts.java
+++ b/servers/zms/src/main/java/com/yahoo/athenz/zms/ZMSConsts.java
@@ -136,7 +136,7 @@ public final class ZMSConsts {
     public static final String ZMS_PROP_QUOTA_ENTITY       = "athenz.zms.quota_entity";
     public static final String ZMS_PROP_QUOTA_SUBDOMAIN    = "athenz.zms.quota_subdomain";
 
-    public static final String ZMS_PROP_USE_LOCAL_TIMEZONE_IN_DOMAIN_SCAN = "athenz.zms.use_local_timezone_in_domain_scan";
+    public static final String ZMS_PROP_MYSQL_SERVER_TIMEZONE = "athenz.zms.mysql_server_timezone";
     
     public static final String ZMS_PRINCIPAL_AUTHORITY_CLASS  = "com.yahoo.athenz.auth.impl.PrincipalAuthority";
 

--- a/servers/zms/src/main/java/com/yahoo/athenz/zms/ZMSConsts.java
+++ b/servers/zms/src/main/java/com/yahoo/athenz/zms/ZMSConsts.java
@@ -136,6 +136,8 @@ public final class ZMSConsts {
     public static final String ZMS_PROP_QUOTA_ENTITY       = "athenz.zms.quota_entity";
     public static final String ZMS_PROP_QUOTA_SUBDOMAIN    = "athenz.zms.quota_subdomain";
 
+    public static final String ZMS_PROP_USE_LOCAL_TIMEZONE_IN_DOMAIN_SCAN = "athenz.zms.use_local_timezone_in_domain_scan";
+    
     public static final String ZMS_PRINCIPAL_AUTHORITY_CLASS  = "com.yahoo.athenz.auth.impl.PrincipalAuthority";
 
     public static final String ZMS_UNKNOWN_DOMAIN     = "unknown_domain";

--- a/servers/zms/src/main/java/com/yahoo/athenz/zms/store/jdbc/JDBCConnection.java
+++ b/servers/zms/src/main/java/com/yahoo/athenz/zms/store/jdbc/JDBCConnection.java
@@ -651,8 +651,6 @@ public class JDBCConnection implements ObjectStoreConnection {
     PreparedStatement prepareDomainScanStatement(String prefix, long modifiedSince)
             throws SQLException {
 
-        Calendar cal = Calendar.getInstance(TimeZone.getTimeZone(MYSQL_SERVER_TIMEZONE));
-
         PreparedStatement ps;
         if (prefix != null && prefix.length() > 0) {
             int len = prefix.length();
@@ -662,6 +660,7 @@ public class JDBCConnection implements ObjectStoreConnection {
                 ps = con.prepareStatement(SQL_LIST_DOMAIN_PREFIX_MODIFIED);
                 ps.setString(1, prefix);
                 ps.setString(2, stop);
+                Calendar cal = Calendar.getInstance(TimeZone.getTimeZone(MYSQL_SERVER_TIMEZONE));
                 ps.setTimestamp(3, new java.sql.Timestamp(modifiedSince), cal);
             } else {
                 ps = con.prepareStatement(SQL_LIST_DOMAIN_PREFIX);
@@ -670,6 +669,7 @@ public class JDBCConnection implements ObjectStoreConnection {
             }
         } else if (modifiedSince != 0) {
             ps = con.prepareStatement(SQL_LIST_DOMAIN_MODIFIED);
+            Calendar cal = Calendar.getInstance(TimeZone.getTimeZone(MYSQL_SERVER_TIMEZONE));
             ps.setTimestamp(1, new java.sql.Timestamp(modifiedSince), cal);
         } else {
             ps = con.prepareStatement(SQL_LIST_DOMAIN);

--- a/servers/zms/src/main/java/com/yahoo/athenz/zms/store/jdbc/JDBCConnection.java
+++ b/servers/zms/src/main/java/com/yahoo/athenz/zms/store/jdbc/JDBCConnection.java
@@ -322,6 +322,8 @@ public class JDBCConnection implements ObjectStoreConnection {
 
     private static final String AWS_ARN_PREFIX  = "arn:aws:iam::";
 
+    private static final String MYSQL_SERVER_TIMEZONE = System.getProperty(ZMSConsts.ZMS_PROP_MYSQL_SERVER_TIMEZONE, "GMT");
+
     Connection con;
     boolean transactionCompleted;
     int queryTimeout = 60;
@@ -648,8 +650,8 @@ public class JDBCConnection implements ObjectStoreConnection {
 
     PreparedStatement prepareDomainScanStatement(String prefix, long modifiedSince)
             throws SQLException {
-        
-        Calendar cal = getCalendarInstance();
+
+        Calendar cal = Calendar.getInstance(TimeZone.getTimeZone(MYSQL_SERVER_TIMEZONE));
 
         PreparedStatement ps;
         if (prefix != null && prefix.length() > 0) {
@@ -675,21 +677,7 @@ public class JDBCConnection implements ObjectStoreConnection {
         return ps;
     }
 
-    Calendar getCalendarInstance() {
-
-        Boolean useLocalTimeZone = Boolean.parseBoolean(
-                System.getProperty(ZMSConsts.ZMS_PROP_USE_LOCAL_TIMEZONE_IN_DOMAIN_SCAN, "false")
-        );
-
-        TimeZone timeZone;
-        if (useLocalTimeZone) {
-            timeZone = TimeZone.getDefault();
-        } else {
-            timeZone = TimeZone.getTimeZone("GMT");
-        }
-        return Calendar.getInstance(timeZone);
-    }
-    
+   
     PreparedStatement prepareScanByRoleStatement(String roleMember, String roleName)
             throws SQLException {
         

--- a/servers/zms/src/test/java/com/yahoo/athenz/zms/store/jdbc/JDBCConnectionTest.java
+++ b/servers/zms/src/test/java/com/yahoo/athenz/zms/store/jdbc/JDBCConnectionTest.java
@@ -5013,65 +5013,7 @@ public class JDBCConnectionTest {
         Mockito.verify(mockPrepStmt, times(1)).setTimestamp(ArgumentMatchers.eq(1), ArgumentMatchers.eq(new java.sql.Timestamp(100)), ArgumentMatchers.isA(Calendar.class));
         jdbcConn.close();
     }
-
-    @Test
-    public void testGetCalendarInstanceWithoutProperty() throws Exception {
-
-        JDBCConnection jdbcConn = new JDBCConnection(mockConn, true);
-        Calendar calendar = jdbcConn.getCalendarInstance();
-
-        TimeZone expected = TimeZone.getTimeZone("GMT");
-        TimeZone actual = calendar.getTimeZone();
-        assertEquals(expected, actual);
-
-        jdbcConn.close();
-    }
-
-    @Test
-    public void testGetCalendarInstanceWithPropertyUsingLocalTimeZone() throws Exception {
-
-        System.setProperty(ZMSConsts.ZMS_PROP_USE_LOCAL_TIMEZONE_IN_DOMAIN_SCAN, "true");
-        JDBCConnection jdbcConn = new JDBCConnection(mockConn, true);
-        Calendar calendar = jdbcConn.getCalendarInstance();
-
-        TimeZone expected = TimeZone.getDefault();
-        TimeZone actual = calendar.getTimeZone();
-        assertEquals(expected, actual);
-
-        jdbcConn.close();
-        System.clearProperty(ZMSConsts.ZMS_PROP_USE_LOCAL_TIMEZONE_IN_DOMAIN_SCAN);
-    }
-
-    @Test
-    public void testGetCalendarInstanceWithPropertyNotUsingLocalTimeZone() throws Exception {
-
-        System.setProperty(ZMSConsts.ZMS_PROP_USE_LOCAL_TIMEZONE_IN_DOMAIN_SCAN, "false");
-        JDBCConnection jdbcConn = new JDBCConnection(mockConn, true);
-        Calendar calendar = jdbcConn.getCalendarInstance();
-
-        TimeZone expected = TimeZone.getTimeZone("GMT");
-        TimeZone actual = calendar.getTimeZone();
-        assertEquals(expected, actual);
-
-        jdbcConn.close();
-        System.clearProperty(ZMSConsts.ZMS_PROP_USE_LOCAL_TIMEZONE_IN_DOMAIN_SCAN);
-    }
-
-    @Test
-    public void testGetCalendarInstanceWithEmptyProperty() throws Exception {
-
-        System.setProperty(ZMSConsts.ZMS_PROP_USE_LOCAL_TIMEZONE_IN_DOMAIN_SCAN, "");
-        JDBCConnection jdbcConn = new JDBCConnection(mockConn, true);
-        Calendar calendar = jdbcConn.getCalendarInstance();
-
-        TimeZone expected = TimeZone.getTimeZone("GMT");
-        TimeZone actual = calendar.getTimeZone();
-        assertEquals(expected, actual);
-
-        jdbcConn.close();
-        System.clearProperty(ZMSConsts.ZMS_PROP_USE_LOCAL_TIMEZONE_IN_DOMAIN_SCAN);
-    }
-
+    
     @Test
     public void testPrepareScanByRoleStatement() throws Exception {
         

--- a/servers/zms/src/test/java/com/yahoo/athenz/zms/store/jdbc/JDBCConnectionTest.java
+++ b/servers/zms/src/test/java/com/yahoo/athenz/zms/store/jdbc/JDBCConnectionTest.java
@@ -5013,7 +5013,65 @@ public class JDBCConnectionTest {
         Mockito.verify(mockPrepStmt, times(1)).setTimestamp(ArgumentMatchers.eq(1), ArgumentMatchers.eq(new java.sql.Timestamp(100)), ArgumentMatchers.isA(Calendar.class));
         jdbcConn.close();
     }
-    
+
+    @Test
+    public void testGetCalendarInstanceWithoutProperty() throws Exception {
+
+        JDBCConnection jdbcConn = new JDBCConnection(mockConn, true);
+        Calendar calendar = jdbcConn.getCalendarInstance();
+
+        TimeZone expected = TimeZone.getTimeZone("GMT");
+        TimeZone actual = calendar.getTimeZone();
+        assertEquals(expected, actual);
+
+        jdbcConn.close();
+    }
+
+    @Test
+    public void testGetCalendarInstanceWithPropertyUsingLocalTimeZone() throws Exception {
+
+        System.setProperty(ZMSConsts.ZMS_PROP_USE_LOCAL_TIMEZONE_IN_DOMAIN_SCAN, "true");
+        JDBCConnection jdbcConn = new JDBCConnection(mockConn, true);
+        Calendar calendar = jdbcConn.getCalendarInstance();
+
+        TimeZone expected = TimeZone.getDefault();
+        TimeZone actual = calendar.getTimeZone();
+        assertEquals(expected, actual);
+
+        jdbcConn.close();
+        System.clearProperty(ZMSConsts.ZMS_PROP_USE_LOCAL_TIMEZONE_IN_DOMAIN_SCAN);
+    }
+
+    @Test
+    public void testGetCalendarInstanceWithPropertyNotUsingLocalTimeZone() throws Exception {
+
+        System.setProperty(ZMSConsts.ZMS_PROP_USE_LOCAL_TIMEZONE_IN_DOMAIN_SCAN, "false");
+        JDBCConnection jdbcConn = new JDBCConnection(mockConn, true);
+        Calendar calendar = jdbcConn.getCalendarInstance();
+
+        TimeZone expected = TimeZone.getTimeZone("GMT");
+        TimeZone actual = calendar.getTimeZone();
+        assertEquals(expected, actual);
+
+        jdbcConn.close();
+        System.clearProperty(ZMSConsts.ZMS_PROP_USE_LOCAL_TIMEZONE_IN_DOMAIN_SCAN);
+    }
+
+    @Test
+    public void testGetCalendarInstanceWithEmptyProperty() throws Exception {
+
+        System.setProperty(ZMSConsts.ZMS_PROP_USE_LOCAL_TIMEZONE_IN_DOMAIN_SCAN, "");
+        JDBCConnection jdbcConn = new JDBCConnection(mockConn, true);
+        Calendar calendar = jdbcConn.getCalendarInstance();
+
+        TimeZone expected = TimeZone.getTimeZone("GMT");
+        TimeZone actual = calendar.getTimeZone();
+        assertEquals(expected, actual);
+
+        jdbcConn.close();
+        System.clearProperty(ZMSConsts.ZMS_PROP_USE_LOCAL_TIMEZONE_IN_DOMAIN_SCAN);
+    }
+
     @Test
     public void testPrepareScanByRoleStatement() throws Exception {
         


### PR DESCRIPTION
## Problem
ZMS uses MySQL Connector/J for DB connections. MySQL Connector/J converted to DB's time zone until 5.x, but from 8.x, it doesn't convert to DB's time zone.

- 5.x (expected behavior): MySQL Connector/J converts GMT to JST when the DB time zone is JST.
- 8.x (Unintended behavior): MySQL Connector/J will not convert GMT even if the DB time zone is JST

When retrieving modified domains from database server, ZMS generates the query with GMT, but the time zone of database is not GMT, so I cannot retrieve modified domains.

Is there any way to convert GMT to localtime when retrieving modified domains?

## Fix
This is an idea to solve this problem.